### PR TITLE
adds scripts to install git and git lfs on centOs 7 image

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,14 @@ echo "================= Installing Java 1.8.0 ==================="
 echo "================= Installing Ruby 2.3.5 ==================="
 . /c7/ruby/install.sh
 
+echo "================= Installing Git ==================="
+sudo yum install git
+
+echo "================= Installing Git LFS ==================="
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash -
+sudo yum install git-lfs
+git lfs install
+
 echo "================= Cleaning package lists ==================="
 yum clean expire-cache
 yum autoremove

--- a/install.sh
+++ b/install.sh
@@ -49,11 +49,11 @@ echo "================= Installing Ruby 2.3.5 ==================="
 . /c7/ruby/install.sh
 
 echo "================= Installing Git ==================="
-sudo yum install git
+sudo yum install git-1.8.3.1
 
 echo "================= Installing Git LFS ==================="
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash -
-sudo yum install git-lfs
+sudo yum install git-lfs-2.3.4
 git lfs install
 
 echo "================= Cleaning package lists ==================="


### PR DESCRIPTION
https://github.com/dry-dock/c7/issues/5

- Verified of running commands to get the versions of git and git lfs on the build image
```
[root@a96e49da7d81 /]# git --version
git version 1.8.3.1
[root@a96e49da7d81 /]# git lfs env
git-lfs/2.3.4 (GitHub; linux amd64; go 1.8.3; git d2f6752)
git version 1.8.3.1

LocalWorkingDir=
LocalGitDir=
LocalGitStorageDir=
LocalMediaDir=
LocalReferenceDir=
TempDir=/tmp/git-lfs
ConcurrentTransfers=3
TusTransfers=false
BasicTransfersOnly=false
SkipDownloadErrors=false
FetchRecentAlways=false
FetchRecentRefsDays=7
FetchRecentCommitsDays=0
FetchRecentRefsIncludeRemotes=true
PruneOffsetDays=3
PruneVerifyRemoteAlways=false
PruneRemoteName=origin
LfsStorageDir=lfs
AccessDownload=none
AccessUpload=none
DownloadTransfers=basic
UploadTransfers=basic
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"
[root@a96e49da7d81 /]# 
```