### PR TITLE
adds scripts for installing gcloud and kubectl cli

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,37 @@ curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.s
 sudo yum install git-lfs-2.3.4
 git lfs install
 
+echo "================= Adding gclould ============"
+sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+sudo yum install -y google-cloud-sdk-189.0.0-1.el7
+
+echo "================= Adding kubectl 1.8.8 ==================="
+curl -sSLO https://storage.googleapis.com/kubernetes-release/release/v1.8.8/bin/linux/amd64/kubectl
+sudo chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+
+KOPS_VERSION=1.8.1
+echo "Installing KOPS version: $KOPS_VERSION"
+curl -LO https://github.com/kubernetes/kops/releases/download/"$KOPS_VERSION"/kops-linux-amd64
+sudo chmod +x kops-linux-amd64
+sudo mv kops-linux-amd64 /usr/local/bin/kops
+
+HELM_VERSION=v2.8.1
+echo "Installing helm version: $HELM_VERSION"
+wget https://storage.googleapis.com/kubernetes-helm/helm-"$HELM_VERSION"-linux-amd64.tar.gz
+tar -zxvf helm-"$HELM_VERSION"-linux-amd64.tar.gz
+mv linux-amd64/helm /usr/local/bin/helm
+rm -rf linux-amd64
+
 echo "================= Cleaning package lists ==================="
 yum clean expire-cache
 yum autoremove


### PR DESCRIPTION
https://github.com/dry-dock/c7/issues/7

- Installing `gcloud` and `kubectl` clis.

```
[root@7011766d10b4 /]# gcloud version
Google Cloud SDK 189.0.0
alpha 2018.02.12
beta 2018.02.12
bq 2.0.29
core 2018.02.12
gsutil 4.28
[root@7011766d10b4 /]# kubectl version
Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.8", GitCommit:"2f73858c9e6ede659d6828fe5a1862a48034a0fd", GitTreeState:"clean", BuildDate:"2018-02-09T21:30:57Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
The connection to the server localhost:8080 was refused - did you specify the right host or port?
[root@7011766d10b4 /]# kops version
Version 1.8.1 (git-94ef202)
[root@7011766d10b4 /]# helm version
Client: &version.Version{SemVer:"v2.8.1", GitCommit:"6af75a8fd72e2aa18a2b278cfe5c7a1c5feca7f2", GitTreeState:"clean"}
```