### PR TITLE
 adds installation scripts for centOS 7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,14 @@ yum -y install -q \
   glibc.i686 \
   libgcc_s.so.1
 
+echo "================= Installing Python packages ==================="
+sudo yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+sudo yum update
+sudo yum install -y python35u python35u-libs python35u-devel python35u-pip
+# Update pip version
+python -m pip install -q -U pip
+pip install -q virtualenv==15.1.0
+
 echo "================= Installing Node 9.x ==================="
 . /c7/node/install.sh
 
@@ -86,6 +94,11 @@ wget https://storage.googleapis.com/kubernetes-helm/helm-"$HELM_VERSION"-linux-a
 tar -zxvf helm-"$HELM_VERSION"-linux-amd64.tar.gz
 mv linux-amd64/helm /usr/local/bin/helm
 rm -rf linux-amd64
+
+echo "================ Adding azure-cli $AZURE_CLI_VERSION  =============="
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+sudo yum install azure-cli
 
 echo "================= Cleaning package lists ==================="
 yum clean expire-cache

--- a/install.sh
+++ b/install.sh
@@ -99,8 +99,8 @@ rm -rf linux-amd64
 echo "================= Adding awscli 1.14.41 ============"
 sudo pip3.5 install -q 'awscli==1.14.41'
 
-echo "================= Adding awsebcli 3.12.3 ============"
-sudo pip3.5 install -q 'awsebcli==3.12.3'
+#echo "================= Adding awsebcli 3.12.3 ============"
+#sudo pip3.5 install -q 'awsebcli==3.12.3'
 
 AZURE_CLI_VERSION=2.0.27
 echo "================ Adding azure-cli $AZURE_CLI_VERSION  =============="
@@ -159,12 +159,10 @@ export PK_FILE=packer_"$PK_VERSION"_linux_amd64.zip
 
 echo "Fetching packer"
 echo "-----------------------------------"
-rm -rf /tmp/packer
-mkdir -p /tmp/packer
-wget -nv https://releases.hashicorp.com/packer/$PK_VERSION/$PK_FILE
-unzip -o $PK_FILE -d /tmp/packer
-sudo chmod +x /tmp/packer/packer
-mv /tmp/packer/packer /usr/bin/packer
+curl -O https://releases.hashicorp.com/packer/1.2.0/packer_1.2.0_linux_amd64.zip
+sudo unzip -d /usr/local packer_1.2.0_linux_amd64.zip
+sudo ln -s /usr/local/packer /usr/local/bin/packer.io
+rm packer_1.2.0_linux_amd64.zip
 
 echo "Added packer successfully"
 echo "-----------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,10 @@ echo "================= Installing Python packages ==================="
 sudo yum install -y https://centos7.iuscommunity.org/ius-release.rpm
 sudo yum update
 sudo yum install -y python35u python35u-libs python35u-devel python35u-pip
-# Update pip version
-python -m pip install -q -U pip
-pip install -q virtualenv==15.1.0
+sudo pip3.5 install -q virtualenv==15.1.0
+
+echo "================= Adding JQ 1.3.1 ==================="
+sudo yum install jq-1.5
 
 echo "================= Installing Node 9.x ==================="
 . /c7/node/install.sh
@@ -95,12 +96,88 @@ tar -zxvf helm-"$HELM_VERSION"-linux-amd64.tar.gz
 mv linux-amd64/helm /usr/local/bin/helm
 rm -rf linux-amd64
 
+echo "================= Adding awscli 1.14.41 ============"
+sudo pip3.5 install -q 'awscli==1.14.41'
+
+echo "================= Adding awsebcli 3.12.3 ============"
+sudo pip3.5 install -q 'awsebcli==3.12.3'
+
+AZURE_CLI_VERSION=2.0.27
 echo "================ Adding azure-cli $AZURE_CLI_VERSION  =============="
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
-sudo yum install azure-cli
+sudo yum install azure-cli-$AZURE_CLI_VERSION
+
+echo "================= Adding doctl 1.7.0 ============"
+curl -OL https://github.com/digitalocean/doctl/releases/download/v1.7.0/doctl-1.7.0-linux-amd64.tar.gz
+tar xf doctl-1.7.0-linux-amd64.tar.gz
+sudo mv doctl /usr/local/bin
+rm doctl-1.7.0-linux-amd64.tar.gz
+
+echo "================= Adding jfrog-cli 1.7.0 ==================="
+wget -nv https://api.bintray.com/content/jfrog/jfrog-cli-go/1.7.0/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 -O jfrog
+sudo chmod +x jfrog
+sudo mv jfrog /usr/bin/jfrog
+
+echo "================ Adding ansible 2.3.0.0 ===================="
+sudo pip3.5 install -q 'ansible==2.3.0.0'
+
+echo "================ Adding boto 2.46.1 ======================="
+sudo pip3.5 install -q 'boto==2.46.1'
+
+echo "============  Adding boto3 ==============="
+sudo pip3.5 install -q 'boto3==1.5.15'
+
+echo "================ Adding apache-libcloud 2.0.0 ======================="
+sudo pip3.5 install -q 'apache-libcloud==2.0.0'
+
+echo "================ Adding azure 2.0.0 ======================="
+sudo pip3.5 install -q 'azure==2.0.0'
+
+echo "================ Adding dopy 0.3.7a ======================="
+sudo pip3.5 install -q 'dopy==0.3.7a'
+
+export TF_VERSION=0.11.3
+echo "================ Adding terraform-$TF_VERSION===================="
+export TF_FILE=terraform_"$TF_VERSION"_linux_amd64.zip
+
+echo "Fetching terraform"
+echo "-----------------------------------"
+rm -rf /tmp/terraform
+mkdir -p /tmp/terraform
+wget -nv https://releases.hashicorp.com/terraform/$TF_VERSION/$TF_FILE
+unzip -o $TF_FILE -d /tmp/terraform
+sudo chmod +x /tmp/terraform/terraform
+mv /tmp/terraform/terraform /usr/bin/terraform
+
+echo "Added terraform successfully"
+echo "-----------------------------------"
+
+export PK_VERSION=1.2.0
+echo "================ Adding packer $PK_VERSION ===================="
+export PK_FILE=packer_"$PK_VERSION"_linux_amd64.zip
+
+echo "Fetching packer"
+echo "-----------------------------------"
+rm -rf /tmp/packer
+mkdir -p /tmp/packer
+wget -nv https://releases.hashicorp.com/packer/$PK_VERSION/$PK_FILE
+unzip -o $PK_FILE -d /tmp/packer
+sudo chmod +x /tmp/packer/packer
+mv /tmp/packer/packer /usr/bin/packer
+
+echo "Added packer successfully"
+echo "-----------------------------------"
+
+echo "================= Intalling Shippable CLIs ================="
+
+git clone https://github.com/Shippable/node.git nodeRepo
+./nodeRepo/shipctl/x86_64/CentOS_7/install.sh
+rm -rf nodeRepo
+
+echo "Installed Shippable CLIs successfully"
+echo "-------------------------------------"
 
 echo "================= Cleaning package lists ==================="
 yum clean expire-cache
 yum autoremove
-

--- a/test_lang.sh
+++ b/test_lang.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -e
+
+echo "================= OS Information ==================="
+printf "\n"
+echo "rpm --query centos-release"
+rpm --query centos-release
+printf "\n\n"
+
+echo "================= Java Version ==================="
+printf "\n"
+echo "java -version"
+java -version
+printf "\n\n"
+
+echo "================= Python Version ==================="
+printf "\n"
+echo "python --version"
+python --version
+printf "\n\n"
+
+echo "================= Node Version ==================="
+printf "\n"
+echo "node --version"
+node --version
+printf "\n\n"
+
+echo "================= Ruby Versions ==================="
+printf "\n"
+echo "rvm list"
+source /usr/local/rvm/scripts/rvm
+rvm list
+
+echo "================= gclould Versions ==================="
+printf "\n"
+echo "gcloud version"
+gcloud version
+
+echo "================= awscli Versions ==================="
+printf "\n"
+echo "aws --version"
+aws --version
+
+echo "================= awsebcli Versions ==================="
+printf "\n"
+echo "eb --version"
+eb --version
+
+echo "================= Terraform Versions ==================="
+printf "\n"
+echo "Terraform --version"
+terraform --version
+
+echo "================= Packer Versions ==================="
+printf "\n"
+echo "Packer --version"
+packer --version
+
+echo "================= JQ Versions ==================="
+printf "\n"
+echo "jq --version"
+jq --version
+
+echo "================= JFrog CLI Versions ==================="
+printf "\n"
+echo "jfrog --version"
+jfrog --version

--- a/test_lang.sh
+++ b/test_lang.sh
@@ -40,10 +40,10 @@ printf "\n"
 echo "aws --version"
 aws --version
 
-echo "================= awsebcli Versions ==================="
-printf "\n"
-echo "eb --version"
-eb --version
+#echo "================= awsebcli Versions ==================="
+#printf "\n"
+#echo "eb --version"
+#eb --version
 
 echo "================= Terraform Versions ==================="
 printf "\n"
@@ -52,8 +52,8 @@ terraform --version
 
 echo "================= Packer Versions ==================="
 printf "\n"
-echo "Packer --version"
-packer --version
+echo "packer.io version"
+packer.io version
 
 echo "================= JQ Versions ==================="
 printf "\n"


### PR DESCRIPTION
https://github.com/dry-dock/c7/issues/7

**NOTE:** Couldnt install `awsebcli`
- It fails with following error.
```
[root@643e2a908d47 /]# sudo pip3.5 install -q 'awsebcli==3.12.3'
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-kdiw84sg/awsebcli/


```
- Apart from this all the installations will be complete with this PR.


```
[root@643e2a908d47 /]# sudo ./test.sh 
================= OS Information ===================

rpm --query centos-release
centos-release-7-4.1708.el7.centos.x86_64


================= Java Version ===================

java -version
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)


================= Python Version ===================

python --version
Python 2.7.5


================= Node Version ===================

node --version
v9.5.0


================= Ruby Versions ===================

rvm list

rvm rubies

=* ruby-2.3.5 [ x86_64 ]

# => - current
# =* - current && default
#  * - default

================= gclould Versions ===================

gcloud version
Google Cloud SDK 189.0.0
alpha 2018.02.12
beta 2018.02.12
bq 2.0.29
core 2018.02.12
gsutil 4.28
================= awscli Versions ===================

aws --version
aws-cli/1.14.41 Python/3.5.4 Linux/3.10.0-514.10.2.el7.x86_64 botocore/1.8.45
================= Terraform Versions ===================

Terraform --version
Terraform v0.11.3

[root@643e2a908d47 /]# packer.io version
Packer v1.2.0

[root@643e2a908d47 /]# jq --version
jq-1.5

[root@643e2a908d47 /]# jfrog --version
jfrog version 1.7.0

```
