### PR TITLE
corrects openjdk8 installation command for centos c7 image

### DIFF
--- a/java/install.sh
+++ b/java/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 echo "================= Installing openjdk-8-jdk ==================="
-sudo yum install -y java-1.8.0-openjdk
+sudo yum install -y java-1.8.0-openjdk-devel
 
 echo "================ Installing oracle-java8-installer ================="
 wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jre-8u161-linux-x64.rpm"


### PR DESCRIPTION
https://github.com/dry-dock/c7javall/issues/1

- `java-1.8.0-openjdk` this rpm package is not having `javac`,  found the correct one `java-1.8.0-openjdk-devel`
